### PR TITLE
Update to nine principles, add Think Ahead (BL-003)

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -7,7 +7,7 @@ description: "Take AI Bite: a framework for human-AI collaboration"
 
 When AI generates faster than you can review, oversight becomes rubber-stamping. You're in the room, but not in the loop. These are principles for structuring AI collaboration so every delivery is small enough to think about, sharp enough to act on, and real enough to earn genuine engagement, not just approval.
 
-## The Eight Principles
+## The Nine Principles
 
 1. **Take a Bite** -- Deliver only what the reviewer can chew
 2. **The Human Brings the Spark** -- AI amplifies; the human provides direction, intuition, and judgment
@@ -17,3 +17,4 @@ When AI generates faster than you can review, oversight becomes rubber-stamping.
 6. **Match the Room** -- Contribute proportionally to the project's culture and scale
 7. **Own Your Process** -- Disclose how the work was produced
 8. **Know What You Own** -- Verify licensing before deployment
+9. **Think Ahead** -- Build the map before you walk the territory


### PR DESCRIPTION
## Summary
- Add Principle 1.9 "Think Ahead" to About page
- Update heading from "Eight Principles" to "Nine Principles"

## Test plan
- [x] Grep confirmed no other "eight principles" references in content or config