### PR TITLE
Post 15 published + 'an AI' singular typography rule

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -67,6 +67,14 @@
 Use comma "," instead of Em Dash "—" for connecting phrases in any language.
 Never use space coma space (" , "). The correct format is no spaces before the comma, and one space after: ", ".
 
+### Typography: avoid "AIs" plural
+In sans-serif fonts (which LinkedIn and most web typography use), capital `I` and lowercase `l` render as identical vertical strokes. "AIs" reads visually as "Als", which breaks reading rhythm.
+
+- **Use singular "an AI"** instead of plural "AIs" in reader-facing prose.
+- When the plural is necessary, prefer rewrites like "these models", "the agents", "AI tools" rather than "AIs".
+- Cascade pronouns when changing plural to singular: "AIs ... their" becomes "an AI ... its".
+- Applies to blog posts, About pages, LinkedIn cross-posts, any reader-facing material.
+
 ### Code Output Standards (reinforces Earn Your Assertions)
 - Show actual values: shapes, metrics, counts, paths
 - No generic confirmations: avoid "Done!", "Success!", "Data loaded successfully!"

--- a/content/blog/2026-06-03-tab-bootstrap-release/index.md
+++ b/content/blog/2026-06-03-tab-bootstrap-release/index.md
@@ -7,7 +7,7 @@ tags: ["take-ai-bite", "claude-code", "release-notes"]
 draft: false
 ---
 
-It is curious how AI, in this case Claude Code, will embark on a quest with topics not entirely explored. That would write the fate for an explorer in counted minutes. However, we humans sometimes think that AIs suggest acting on something based on their own training, as if training is equivalent to knowledge. Try entering the Amazon jungle without knowledge and see if you walk out at all.
+It is curious how AI, in this case Claude Code, will embark on a quest with topics not entirely explored. That would write the fate for an explorer in counted minutes. However, we humans sometimes think that an AI suggests acting on something based on its own training, as if training is equivalent to knowledge. Try entering the Amazon jungle without knowledge and see if you walk out at all.
 
 I have a few examples that took me to realize an important pattern that was fixed with a new principle to the framework: Read the User's Manual (DSM_6.0 §1.11).
 

--- a/dsm-docs/blog/linkedin-posts.md
+++ b/dsm-docs/blog/linkedin-posts.md
@@ -370,3 +370,29 @@ There is a name for the role behind this: PMO Director of an AI-agent workforce.
 Full post: https://take-ai-bite.com/blog/2026-05-28-pmo-director-agentic-stakeholder/
 
 #ProjectManagement #PMO #Leadership #HumanAICollaboration #TakeAIBite
+
+## Post 15: How Take AI Bite learned to bootstrap itself (2026-06-03)
+
+**URL:** https://www.linkedin.com/posts/albertodiazdurana_how-take-ai-bite-learned-to-bootstrap-itself-share-7468948595631742976-SNd3/
+**Status:** Published
+**Blog post:** https://take-ai-bite.com/blog/2026-06-03-tab-bootstrap-release/
+**Source:** BL-022 Front E (LinkedIn cross-post for the v1.5/v1.6 release post "How Take AI Bite learned to bootstrap itself").
+**Hashtag set:** #AI #HumanAICollaboration #ClaudeCode #AIAgents #TakeAIBite. First Take AI Bite post applying the new CLAUDE.md TAB/DSM convention (drops #DSM, keeps #TakeAIBite as the brand tag).
+**Slug observation (BL-023):** slug is TITLE-derived (`how-take-ai-bite-learned-to-bootstrap-itself`), NOT hashtag-derived. New outcome class compared to Posts 10-13 (hashtag-based, varied lead-tags) and Post 14 (hashtag-based, matched first 3 declared tags). LinkedIn's slug algorithm appears to sometimes pick the linked post title over hashtag tags. Possible factors to investigate in BL-023: title distinctiveness, hashtag overlap with other posts on the platform, link visibility in the post body.
+**Note:** Published version of the text contains "AIs" plural. This linkedin-posts.md file has been updated to "an AI" singular per the new CLAUDE.md typography rule, but the live LinkedIn post retains the original wording.
+
+**Text:**
+
+It is curious how AI, in this case Claude Code, will embark on a quest with topics not entirely explored. That would write the fate for an explorer in counted minutes. We humans sometimes think an AI suggests acting on something based on its own training, as if training is equivalent to knowledge. Try entering the Amazon jungle without knowledge and see if you walk out at all.
+
+My favorite example surprised me the most: Claude Code actively suggesting to create Skills and Hooks without entirely knowing how Anthropic defines them. It is like saying "hey, I'm a surgeon, let's operate because I know I can fix this... but I do not know how to deal with an artery." The agent treats Skills and Hooks as concepts it knows from training, proposes shapes that do not match the actual Anthropic spec, ships them with confidence. The mess shows up later, in the form of a hook that does not fire or a frontmatter field that gets silently ignored.
+
+A smaller version of the same story: an agent ran `gh pr create` against a repo whose default branch had been silently pointed at a session branch that no longer existed. Forty-five minutes went into investigating what looked like a GitHub outage and turned out to be a single `gh repo view` call we had not thought to make.
+
+The pattern got a name: Read the User's Manual. Before you commit to using something, find out what it actually is. The principle now has a hard gate behind it (default-branch verification at session start), a dedicated platform-quirks file the agent reads, and a self-bootstrapping protocol for fresh public-mirror clones.
+
+What v1.5 and v1.6 of Take AI Bite teach me about how the framework actually grows: it names the assumption it just paid for, and turns the name into a thing the project can rely on next time.
+
+Full post: https://take-ai-bite.com/blog/2026-06-03-tab-bootstrap-release/
+
+#AI #HumanAICollaboration #ClaudeCode #AIAgents #TakeAIBite


### PR DESCRIPTION
## Summary

- **Post 15 published** on LinkedIn (Bootstrap release cross-post). URL recorded in linkedin-posts.md, Status: Published.
- **BL-023 slug observation:** Post 15 slug is title-derived (`how-take-ai-bite-learned-to-bootstrap-itself`), not hashtag-derived. New outcome class for the hashtag-vs-slug research thread.
- **New CLAUDE.md rule:** "an AI" singular instead of "AIs" plural. Sans-serif `I` and `l` are identical strokes, "AIs" reads as "Als" and breaks rhythm.
- **Applied the rule** to the live blog post and to Post 15 in `linkedin-posts.md`. Live LinkedIn post retains the original "AIs" wording; the file is the source-of-truth for future re-use.

## Test plan

- [ ] GitHub Actions deploy succeeds
- [ ] https://take-ai-bite.com/blog/2026-06-03-tab-bootstrap-release/ still resolves
- [ ] Updated sentence reads "an AI suggests... based on its own training" on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)