### PR TITLE
Bump GitHub Pages actions off deprecated Node 20 (BL-028)

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -38,14 +38,14 @@ jobs:
           && echo "${{ runner.temp }}/dart-sass" >> $GITHUB_PATH
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Hugo
         env:
@@ -59,7 +59,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 
@@ -72,4 +72,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/dsm-docs/plans/BL-028-pages-actions-node24-bump.md
+++ b/dsm-docs/plans/BL-028-pages-actions-node24-bump.md
@@ -1,0 +1,37 @@
+# BL-028: Bump GitHub Pages actions off deprecated Node 20
+
+**Status:** Open
+**Priority:** Low
+**Date Created:** 2026-06-30 (Session 27)
+**Source:** S27 deploy of PR #47. The Pages deploy run logged: "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/deploy-pages@v4."
+**Origin:** GitHub is retiring Node 20 from Actions runners (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Actions still declaring `runs.using: node20` are force-run on Node 24 with a warning during the transition. When the forced fallback ends, a node20-pinned action will fail to start.
+
+## Problem
+
+`.github/workflows/hugo.yml` pins four official actions at majors that predate the Node 24 runtime:
+
+| Action | Was | Latest (verified node24) |
+|--------|-----|--------------------------|
+| `actions/checkout` | v4 | v7.0.0 (`using: node24`) |
+| `actions/configure-pages` | v5 | v6.0.0 (`using: node24`) |
+| `actions/upload-pages-artifact` | v3 | v5.0.0 (`using: composite`) |
+| `actions/deploy-pages` | v4 | v5.0.0 (`using: node24`) |
+
+The site build itself uses no Node (Hugo is a Go binary; Dart Sass is a standalone binary), so this is purely the runtime that executes the JS actions. Deploys are currently green; the risk is future breakage when GitHub ends the forced fallback.
+
+## Verification done (S27)
+
+Latest release tags pulled via `gh api repos/<r>/releases/latest`. Each tag's `action.yml` `runs.using` checked via `gh api .../contents/action.yml?ref=<tag>` and confirmed node24 (or composite). The `with:` params in our workflow (checkout `submodules`/`fetch-depth`, upload `path`) are stable across these majors.
+
+## Fix
+
+Bump all four to the verified latest majors in `.github/workflows/hugo.yml`. Confirm the next deploy run is green with no Node 20 deprecation warning.
+
+## Success criteria
+
+- Workflow pins all four Pages actions at node24-targeting majors.
+- A deploy run completes green with no "Node.js 20 is deprecated" warning.
+
+## Outcome
+
+- (S27) **Done.** Bumped checkout@v4 -> v7, configure-pages@v5 -> v6, upload-pages-artifact@v3 -> v5, deploy-pages@v4 -> v5. Verified next deploy: TBD.

--- a/dsm-docs/plans/README.md
+++ b/dsm-docs/plans/README.md
@@ -19,6 +19,7 @@ Backlog items for the blog-poster project. Each item is a standalone file with d
 | BL-024 | ["Investigation-first" blog post + LinkedIn cross-post (Haystack OSS arc)](BL-024-haystack-investigation-first-post.md) | Medium | After BL-022 Stage 3 |
 | BL-025 | [DSM v1.10-v1.14 cumulative release coverage (multi-front)](BL-025-dsm-v1.10-v1.14-release-coverage.md) | High | Active (Front B absorbed by BL-027) |
 | BL-027 | [DSM v1.15-v1.17 cumulative release coverage (multi-front)](BL-027-dsm-v1.15-v1.17-release-coverage.md) | High | Active (Stage 2 Front B + C done) |
+| BL-028 | [Bump GitHub Pages actions off deprecated Node 20](BL-028-pages-actions-node24-bump.md) | Low | Active (fix applied S27) |
 
 ## Completed
 


### PR DESCRIPTION
Clears the "Node.js 20 is deprecated ... actions/deploy-pages@v4" warning logged on the PR #47 deploy.

Bumped all four official Pages actions to their latest majors (verified `runs.using: node24` / composite via `gh api`):

- `actions/checkout` v4 -> v7
- `actions/configure-pages` v5 -> v6
- `actions/upload-pages-artifact` v3 -> v5
- `actions/deploy-pages` v4 -> v5

Site build uses no Node (Hugo + Dart Sass binaries); this only affects the runtime executing the JS actions. `with:` params unchanged across majors. BL-028 records the verification.