### PR TITLE
Publish v1.10-v1.12 release post: guardrails

### DIFF
--- a/content/blog/2026-07-06-tab-safe-defaults-release/index.md
+++ b/content/blog/2026-07-06-tab-safe-defaults-release/index.md
@@ -1,0 +1,38 @@
+---
+title: "How Take AI Bite learned to build its own guardrails"
+date: 2026-07-06
+description: "Take AI Bite v1.10 through v1.12 add guardrails: changes that make an unsafe operation impossible or blocked, rather than asking the agent to remember to avoid it. A short walk through what each one prevents."
+categories: ["Methodology"]
+tags: ["take-ai-bite", "claude-code", "release-notes"]
+draft: false
+---
+
+Take AI Bite versions 1.10 through 1.12 are a batch of guardrails. They target ways a working session could quietly damage its own files: a log that grew until it was unusable, an archive overwritten by a routine move, a commit landing in the wrong repository.
+
+There is something fractal about the set. A fractal repeats its whole shape at smaller and smaller scale, and each of these guardrails is a small copy of the one idea the framework runs on, to make the safe path the one you get by default, set down at the scale of a single edit, file, or repository.
+
+None of the failures were carelessness. Each was an ordinary operation whose default behavior happened to be destructive in one specific situation. Telling the agent to be more careful does not close that gap; changing what the operation does closes it.
+
+Here is what each guardrail prevents, and how Take AI Bite propagates each fix so the same failure does not recur across the ecosystem.
+
+## Guardrails built into the workflow
+
+The first two change how a routine file operation behaves, so the damaging version of it can no longer happen.
+
+When a session finishes processing an item from its inbox, it moves the file into a `done/` archive. The old convention named the archived file after its source, so a second entry from the same source moved on top of the first and replaced it. That is exactly what happened once: a move overwrote a rolling archive and 323 lines vanished, caught only before the commit. The fix is a filename. Archived entries now carry the date in their name, so two of them never collide and the move has nothing to overwrite. Nothing has to detect the collision or clean up after it. With two filenames that cannot coincide, it simply cannot happen.
+
+The second guardrail draws a line around git. Take AI Bite projects often sit in a hub-and-spoke layout, and a session in one repository sometimes needs to drop a file into another, a notification or a piece of feedback. The write itself is fine. The problem was that a session would also run git commands in that other repository, and once a background session committed on another project's active branch and swept that project's staged work into the commit. The rule now is narrow: a session may write files into a repository it does not own, but may not run git there. The repository that owns the code owns its history. The stray commit is no longer a mistake to avoid, it is an action the session does not take.
+
+## Guardrails at the moment of action
+
+The other two sit at the point where an action happens and decide whether it goes through.
+
+One is a check that refuses a single kind of edit. The runaway log came from a find-and-replace with "replace every match" turned on, run against text that appeared more than once, so each match pasted the same block and the file grew at every step. One such edit reached 95 megabytes before anyone noticed. Replacing every match is a normal thing to want, so the guardrail is specific rather than broad: a check refuses that one kind of edit on the session log in particular, before it runs, and names the safe way to make the same change. It is not advice the agent can read and then override. The edit does not happen.
+
+The other is a correction to a guardrail that had started firing too often. Writing a file into another repository asks for confirmation, which is the right default. But during the end-of-session routine the same confirmation came up again and again for destinations the protocol already knows are safe, the project's own memory, a sibling project's inbox. A check that interrupts you on safe actions trains you to wave it through, and that habit is exactly how the dangerous one slips past. So the routine now confirms those known destinations once, up front, and the check keeps its force for the writes that actually warrant a look.
+
+## The same shape at every scale
+
+That is the fractal shape from the opening, seen whole. Blocking one edit on one file, dating one archive name, drawing a line around git in one repository: each is the same move as the framework it belongs to, the safe path made into the default. Zoom in on the smallest check and you find the idea the whole methodology runs on. Zoom out to the methodology and it is that check again, repeated wherever a failure has shown the default was unsafe.
+
+It is also how Take AI Bite grows, and it does not grow in only one place. The guardrails are not planned in advance; each is added at the scale where something went wrong. But a fix made on one project does not stay there. Take AI Bite runs as a hub and its spokes, and an improvement proven on one spoke returns through the hub to all of them. That movement has a name here, propagation, and it is the concrete counterpart to the abstract picture: fractal in shape, propagation in reach. A single overwritten archive on one project becomes, a version later, a guardrail every project already has.

--- a/dsm-docs/blog/linkedin-posts.md
+++ b/dsm-docs/blog/linkedin-posts.md
@@ -526,7 +526,7 @@ Automating a process with an agent is two engineering disciplines wearing one pr
 
 The analytics pipeline is a data-engineering problem. You pull data from source systems, turn raw events into a clean log, check quality, run it on a schedule, and keep it alive when a feed breaks at 2 a.m. The failure modes are well known and the tools are stable.
 
-The agent in production is an LLMOps problem. It is not deterministic, so you cannot test it once and call it correct. A right-looking answer can hide a wrong path. So you trace every step, sample the traces, score them, and feed the failures back. Prompts become versioned artifacts. Cost and latency become first-order concerns. And prompt injection get the necessary attention as a real attack surface.
+The agent in production is an LLMOps problem. It is not deterministic, so you cannot test it once and call it correct. A right-looking answer can hide a wrong path. So you trace every step, sample the traces, score them, and feed the failures back. Prompts become versioned artifacts. Cost and latency become first-order concerns. And prompt injection gets the necessary attention as a real attack surface.
 
 The deepest split is how they fail. A pipeline fails loudly: a feed stops, an alert fires. An agent fails quietly: it keeps answering, just a little worse, and you only notice if you are sampling.
 
@@ -538,13 +538,13 @@ Full post: https://take-ai-bite.com/blog/pm-agentic-part-3/
 
 ## Post 21: Autonomy is earned, not switched on (PM series Part 4) (2026-06-24)
 
-**URL:** (pending publish)
-**Status:** Draft
+**URL:** https://www.linkedin.com/posts/albertodiazdurana_aiinproduction-humanaicollaboration-aiagents-share-7478715733686931456-udWK/
+**Status:** Published
 **Blog post:** https://take-ai-bite.com/blog/pm-agentic-part-4/
-**Source:** PM-agentic series Part 4 (In Production). Per-part LinkedIn cross-post; series closer.
+**Source:** PM-agentic series Part 4 (In Production). Per-part LinkedIn cross-post; series closer. Closes the PM-agentic 4-part LinkedIn series (Posts 18-21).
 **Hashtag set:** #AIinProduction #HumanAICollaboration #AIAgents #MLOps #TakeAIBite (drops #DSM; keeps #TakeAIBite).
 **Note:** Humanizer pass run on the blog post. ~260 words.
-**Slug observation (BL-023):** lead-3 hashtags #AIinProduction #HumanAICollaboration #AIAgents; record slug on publish.
+**Slug observation (BL-023):** predicted lead-3 hashtags #AIinProduction #HumanAICollaboration #AIAgents; CONFIRMED slug `aiinproduction-humanaicollaboration-aiagents-share` (lead-3-hashtag-derived, "share" appended before activity id). Opener not a clean keyword phrase, so lead-hashtag branch as expected (consistent with the S26 refined hypothesis direction). A clean-prediction case; does not bear on the S28 Post 15-vs-22 non-determinism finding (which was identical inputs, divergent derivation).
 
 **Text:**
 
@@ -561,8 +561,6 @@ The thread through the whole series: let evidence earn each step, and keep a hum
 Full post: https://take-ai-bite.com/blog/pm-agentic-part-4/
 
 #AIinProduction #HumanAICollaboration #AIAgents #MLOps #TakeAIBite
-
-"Take AI Bite, labeled DSM (Deliberate Systematic Methodology) in the chart, sits at maximum human oversight and is the only system that accumulates curated experience. The nearest tool is two full levels down, and the level just below it sits empty."
 
 ## Post 22: How Take AI Bite learned to catch its own slips (2026-07-02)
 

--- a/dsm-docs/checkpoints/done/2026-07-03_s28_checkpoint.md
+++ b/dsm-docs/checkpoints/done/2026-07-03_s28_checkpoint.md
@@ -1,3 +1,5 @@
+**Consumed at:** Session 29 start (2026-07-03)
+
 # Session 28 Checkpoint
 **Date:** 2026-07-03
 **Branch:** session-28/2026-07-02-post-deploy


### PR DESCRIPTION
Publishes the v1.10-v1.12 release post, "How Take AI Bite learned to build its own guardrails" (BL-025/BL-027 Front A, Post A of the theme split).

The post covers four guardrails from v1.10-v1.12 (F-129, F-130, F-131, F-132): dated inbox-done filenames, write-only cross-repo git, the transcript replace-all block, and cross-repo target pre-confirmation. Framed around a fractal/propagation bookend, the same safe-by-default move repeated down every scale and propagated across the hub-and-spoke ecosystem.

Also records LinkedIn Post 21 (PM series Part 4) as published and moves the S28 checkpoint to done/ (S29 boot housekeeping).

Process: chunked-drafting Gates 1-4, /humanizer pass (clean), local Hugo build clean (102 pages). ~860 words.