### PR TITLE
Retitle guardrails post + Post 23 draft

### DIFF
--- a/content/blog/2026-07-06-tab-safe-defaults-release/index.md
+++ b/content/blog/2026-07-06-tab-safe-defaults-release/index.md
@@ -1,5 +1,5 @@
 ---
-title: "How Take AI Bite learned to build its own guardrails"
+title: "How Take AI Bite builds its own guardrails"
 date: 2026-07-06
 description: "Take AI Bite v1.10 through v1.12 add guardrails: changes that make an unsafe operation impossible or blocked, rather than asking the agent to remember to avoid it. A short walk through what each one prevents."
 categories: ["Methodology"]

--- a/dsm-docs/blog/linkedin-posts.md
+++ b/dsm-docs/blog/linkedin-posts.md
@@ -589,3 +589,26 @@ If you build with an agent, the question worth sitting with is this: what is you
 Full post: https://take-ai-bite.com/blog/2026-07-02-tab-slip-catching-release/
 
 #AI #HumanAICollaboration #ClaudeCode #AIAgents #TakeAIBite
+## Post 23: How Take AI Bite builds its own guardrails (2026-07-06)
+
+**URL:** (pending publish)
+**Status:** Draft
+**Blog post:** https://take-ai-bite.com/blog/2026-07-06-tab-safe-defaults-release/
+**Source:** BL-025/BL-027 Front E (LinkedIn cross-post for the v1.10-v1.12 release post "How Take AI Bite builds its own guardrails"). Post A of the v1.10-v1.17 theme split; sibling of Posts 15 + 22 (the release-post series).
+**Hashtag set:** #Guardrails #HumanAICollaboration #ClaudeCode #AIAgents #TakeAIBite. Leads with the topical #Guardrails (drops #AI) to make the slug distinctive; keeps #TakeAIBite as the brand tag, drops #DSM per the CLAUDE.md convention.
+**Slug observation (BL-023):** predict lead-3 hashtags -> `guardrails-humanaicollaboration-claudecode`; opener not a clean keyword phrase, so lead-hashtag branch expected. Record actual slug on publish.
+**Note:** ~200 words. Matches the blog post's plain, near-impersonal register; leads with the fractal/propagation frame to introduce the guardrail principle. "an AI" singular, comma-not-em-dash.
+
+**Text:**
+
+Take AI Bite versions 1.10 through 1.12 add guardrails, and there is something fractal about them. A fractal repeats its whole shape at smaller and smaller scale. Each guardrail is a small copy of the one idea the framework runs on, make the safe path the one you get by default, set down at the scale of a single edit, file, or repository.
+
+A guardrail is not a reminder to be careful. It changes what an ordinary operation does, so the damaging version can no longer happen. A move that used to overwrite an archive now lands on a dated name that cannot collide. A session may write into another repository but not run git there. A narrow check refuses a runaway edit before it happens. None of them ask anyone to remember anything.
+
+And because Take AI Bite runs as a hub and its spokes, a fix proven on one project propagates to all of them. Fractal in shape, propagation in reach. A single overwritten archive on one project becomes, a version later, a guardrail every project already has.
+
+That is how the framework grows.
+
+Full post: https://take-ai-bite.com/blog/2026-07-06-tab-safe-defaults-release/
+
+#Guardrails #HumanAICollaboration #ClaudeCode #AIAgents #TakeAIBite

--- a/dsm-docs/plans/BL-025-dsm-v1.10-v1.14-release-coverage.md
+++ b/dsm-docs/plans/BL-025-dsm-v1.10-v1.14-release-coverage.md
@@ -47,6 +47,8 @@ Reconstruction trail per CLAUDE.md pipeline Stage 3 mandatory reading order.
 
 **Blocked on:** BL-022 Front A completion.
 
+**Update (S29):** v1.10-v1.17 split by theme (not BL range) into two posts. **Post A** (v1.10-v1.12 guardrails cluster, F-129..F-132) is **PUBLISHED (2026-07-06)**: "How Take AI Bite builds its own guardrails", https://take-ai-bite.com/blog/2026-07-06-tab-safe-defaults-release/ (PR #52). Post A covers this BL's F-130/F-131/F-132 (plus F-129 from BL-027's carry-over). The v1.13-v1.14 features from this BL's range (F-134 User-Reframes-Proposal, F-135 Introduce Once) belong to **Post B** (v1.13-v1.17 cluster), still pending. Front E LinkedIn for Post A pending. Sequencing + closure tracked in BL-027 (which absorbs this BL's remaining fronts).
+
 ### Front B: Features post update
 
 `content/blog/2026-03-20-dsm-features-three-dimensions/index.md`. Count update 129 → 136 (verify before publishing). Weave F-130 through F-136 into the three dimensions as integrations, not a list.

--- a/dsm-docs/plans/BL-027-dsm-v1.15-v1.17-release-coverage.md
+++ b/dsm-docs/plans/BL-027-dsm-v1.15-v1.17-release-coverage.md
@@ -51,6 +51,12 @@ F-129 through F-135 carry over from the BL-025 range (v1.10-v1.14) that Front B 
 ### Front A: Release blog post(s)
 Story-shaped post(s) following the 5-part structure (Hook, Insight, Fix, Bonus, Takeaway). Reconstruction trail per CLAUDE.md pipeline Stage 3. **Blocked on:** BL-022 + BL-025 Front A.
 
+**Bundling decision (S29):** the v1.10-v1.17 range was split by theme, not by BL range, into two thesis-driven posts. **Post A** = v1.10-v1.12 "guardrails" cluster (F-129..F-132); **Post B** = v1.13-v1.17 "naming the behavior a principle implies" cluster (F-134..F-141, incl. the 14th principle Observe Before Engaging). F-133 (smoke tests as named artifact) dropped from Post A (not a guardrail); reassign to Post B or omit.
+
+**Post A: PUBLISHED (2026-07-06, S29).** "How Take AI Bite builds its own guardrails", https://take-ai-bite.com/blog/2026-07-06-tab-safe-defaults-release/ (PR #52). Covers F-129/F-130/F-131/F-132. Chunked-drafting Gates 1-4 + humanizer pass; fractal/propagation bookend. Live-verified.
+
+**Post B: PENDING** (v1.13-v1.17 cluster). Front A does not fully close until Post B ships.
+
 ### Front B: Features post update
 `content/blog/2026-03-20-dsm-features-three-dimensions/index.md`. Count 129 -> 142. Weave F-129 through F-141 into the three dimensions as integrations, not a list. **Status: shipped S27** (see Outcomes). Weaving map:
 - **Human Oversight (guardrails grow outward + lifecycle):** F-129 (cross-repo write-only), F-136 (Soft Injection / Frame Capture), F-137 (Voice-Attribution Review), F-132 (collision-safe inbox-done), F-131 (wrap-up cross-repo pre-confirm), F-130 (transcript replace_all guard), F-139 (open-PR CI at boot), F-140 (STAA reminder crash-recovery fix).


### PR DESCRIPTION
Retitles the v1.10-v1.12 release post from "How Take AI Bite learned to build its own guardrails" to "How Take AI Bite builds its own guardrails".

The "learned to X" template implies a first-time capability acquired that version (as in the two prior release posts). But Take AI Bite already set guardrails (hooks, rules) before v1.10, so this release is four more guardrails, not the invention of guardrail-building. Present tense is truer to the ongoing practice. The live slug (`tab-safe-defaults-release`) does not contain the title words, so the URL is unchanged.

Also drafts LinkedIn Post 23 (BL-025/BL-027 Front E) and records Post A published / Post B pending in the two coverage BLs.