### PR TITLE
Session 33 post-wrap: push feedback to DSM Central, archive sources

### DIFF
--- a/.claude/last-wrap-up.txt
+++ b/.claude/last-wrap-up.txt
@@ -1,3 +1,3 @@
-session: 32
-date: 2026-07-26
+session: 33
+date: 2026-07-31
 type: full

--- a/_inbox/done/2026-07-30_staa-s32.md
+++ b/_inbox/done/2026-07-30_staa-s32.md
@@ -1,5 +1,7 @@
 ### [2026-07-30] Feedback file pending push to DSM Central: ugrep shim breaks `/dsm-go` baseline checksums
 
+**Status:** Pushed 2026-07-31 (S33 wrap-up). All three action-item steps complete.
+
 **Type:** Action Item
 **Priority:** High
 **Source:** STAA run analyzing S32 (this project)

--- a/dsm-docs/feedback-to-dsm/done/2026-07-30_ugrep-shim-breaks-dsm-go-baseline-checksums.md
+++ b/dsm-docs/feedback-to-dsm/done/2026-07-30_ugrep-shim-breaks-dsm-go-baseline-checksums.md
@@ -1,5 +1,7 @@
 # Two published `/dsm-go` snippets fail against their real input: Step 5 baseline checksums and the Step 1.8 CHANGELOG version read
 
+**Pushed:** 2026-07-31 (S33 wrap-up, to `dsm-central/_inbox/dsm-blog-poster.md`)
+
 **Date:** 2026-07-30
 **Project:** dsm-blog-poster
 **Sessions:** Instance 1 filed by the STAA run analyzing S32 (finding originated in the S32 `/dsm-go` boot, 2026-07-25). Instance 2 and the shared-pattern section added in S33 (2026-07-30), found at the S33 boot.


### PR DESCRIPTION
Pushes both DSM Central defects (the ugrep shim emptying `/dsm-go` baseline checksums, and the `## [vX.Y.Z]` CHANGELOG heading spec that never matches) plus the 7 S33 reasoning lessons to the hub inbox, write-only.

Archives the source report and the S32 STAA action item that carried it, both under dated names. Also carries the wrap-up type marker that branch protection rejected on main.